### PR TITLE
Remove some unreachable code

### DIFF
--- a/Marshal.cs
+++ b/Marshal.cs
@@ -257,13 +257,11 @@ namespace DiscImageChef.Helpers
                         ? ByteArrayToStructureLittleEndian<T>(bytes)
                         : SpanToStructureLittleEndian<T>(bytes);
 
-                    break;
                 case BitEndian.Big:
                     return properties.HasReferences
                         ? ByteArrayToStructureBigEndian<T>(bytes)
                         : SpanToStructureBigEndian<T>(bytes);
 
-                    break;
 
                 case BitEndian.Pdp:
                     return properties.HasReferences


### PR DESCRIPTION
Because these will always return something, the break statements can never be reached. Fixes some warnings.